### PR TITLE
Solved problem for "IAB Helper" not setup

### DIFF
--- a/Donations/src/main/java/org/sufficientlysecure/donations/DonationsFragment.java
+++ b/Donations/src/main/java/org/sufficientlysecure/donations/DonationsFragment.java
@@ -217,7 +217,15 @@ public class DonationsFragment extends Fragment {
 
                 @Override
                 public void onClick(View v) {
-                    donateGoogleOnClick(v);
+                    try {
+                        donateGoogleOnClick(v);
+                    } catch (IllegalStateException e) {     // In some devices, it is impossible to setup IAB Helper
+                        if (mDebug)                         // and this exception is thrown, being almost "impossible"
+                            Log.e(TAG, e.getMessage());     // to the user to control it and forcing app close.
+                        openDialog(android.R.drawable.ic_dialog_alert, 
+                                   R.string.donations__google_android_market_not_supported_title,
+                                   getString(R.string.donations__google_android_market_not_supported));
+                    }
                 }
             });
 


### PR DESCRIPTION
In some devices, when a users clicks the button in order to make a donation, this exception is thrown because that Google Play may is not active or similar.
As this is managed by the lib, the user finds "impossible" (except by doing this trick: https://pastebin.com/Wda6FwPz) to catch and handle the exception.

The solution is implement an exception handler which shows a dialog (using the existing function "`public void openDialog(int icon, int title, String message)`") that inform users their phone does not support in-app purchases